### PR TITLE
Enable 13th (check-digit) (EAN-13) transmission for HW devices

### DIFF
--- a/android/src/main/kotlin/no/talgoe/scanwedge/scanwedge/HoneywellPlugin.kt
+++ b/android/src/main/kotlin/no/talgoe/scanwedge/scanwedge/HoneywellPlugin.kt
@@ -88,7 +88,6 @@ class HoneywellPlugin(private val scanW: ScanwedgePlugin, private val log: Logge
                 putBoolean("TRIG_ENABLE", false)
             })
         })
-        // scanW.sendBroadcast(Intent(ACTION_RELEASE_SCANNER).apply{ setPackage("com.intermec.datacollectionservice") })
         return true
     }
     
@@ -100,16 +99,18 @@ class HoneywellPlugin(private val scanW: ScanwedgePlugin, private val log: Logge
                 putBoolean("TRIG_ENABLE", true)
             })
         })
-        // scanW.sendBroadcast(Intent(ACTION_CLAIM_SCANNER).apply{ setPackage("com.intermec.datacollectionservice") })
         return true
     }
 
     override fun createProfile(name: String, enabledBarcodes: List<BarcodePlugin>?, hwConfig: HashMap<String,Any>?, keepDefaults: Boolean):Boolean {
         log?.i(TAG, "createProfile($name, $enabledBarcodes, $hwConfig, $keepDefaults)")
+        @Suppress("UNCHECKED_CAST")
+        val extraConfig = hwConfig?.get("honeywell") as HashMap<String, Boolean>
         val properties = Bundle().apply{
             putBoolean("DPR_DATA_INTENT", true)
             putString("DPR_DATA_INTENT_ACTION", ScanwedgePlugin.SCANWEDGE_ACTION)
             putString("DPR_DATA_INTENT_CATEGORY", "SCAN")
+            extraConfig["enableEanCheckDigitTransmission"]?.let { putBoolean("DEC_EAN13_CHECK_DIGIT_TRANSMIT", it) }
         }
         val honeywellDefaultTypes=BarcodeTypes.honeywellDefaultTypes().toMutableList()
         if(enabledBarcodes!=null){

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -37,17 +37,34 @@ class _MyAppState extends State<MyApp> {
 
   _createProfile() async {
     try {
-      log('_createProfile()-${await _scanwedgePlugin?.createScanProfile(_scanwedgePlugin?.manufacturer == 'ZEBRA' ? ZebraProfileModel(profileName: 'DemoProfile', enabledBarcodes: [
-            BarcodeConfig(barcodeType: BarcodeTypes.code39),
-            BarcodeConfig(barcodeType: BarcodeTypes.code128),
-            BarcodeConfig(barcodeType: BarcodeTypes.ean8),
-            BarcodeConfig(barcodeType: BarcodeTypes.ean13),
-            BarcodeConfig(barcodeType: BarcodeTypes.i2of5),
-          ], enableKeyStroke: !notifierDisableKeystroke.value, aimType: notifierAimType.value) : ProfileModel(profileName: 'DemoProfile', enabledBarcodes: [
-            BarcodeTypes.code39.create(),
-            BarcodeTypes.code128.create(minLength: 10, maxLength: 15),
-            BarcodeTypes.qrCode.create(),
-          ], keepDefaults: false))}');
+      final wasCreateProfileSuccessful =
+          await _scanwedgePlugin?.createScanProfile(
+        switch (_scanwedgePlugin?.manufacturer) {
+          'ZEBRA' => ZebraProfileModel(
+              profileName: 'DemoProfile',
+              enabledBarcodes: [
+                BarcodeConfig(barcodeType: BarcodeTypes.code39),
+                BarcodeConfig(barcodeType: BarcodeTypes.code128),
+                BarcodeConfig(barcodeType: BarcodeTypes.ean8),
+                BarcodeConfig(barcodeType: BarcodeTypes.ean13),
+                BarcodeConfig(barcodeType: BarcodeTypes.i2of5),
+              ],
+              enableKeyStroke: !notifierDisableKeystroke.value,
+              aimType: notifierAimType.value,
+            ),
+          _ => ProfileModel(
+              profileName: 'DemoProfile',
+              enabledBarcodes: [
+                BarcodeTypes.code39.create(),
+                BarcodeTypes.code128.create(minLength: 10, maxLength: 15),
+                BarcodeTypes.qrCode.create(),
+              ],
+              keepDefaults: false,
+            ),
+        },
+      );
+
+      log('_createProfile()-$wasCreateProfileSuccessful');
     } catch (e) {
       log('_createProfile Exception: $e');
     }
@@ -95,7 +112,9 @@ class _MyAppState extends State<MyApp> {
                 'trigger' => _triggerScan(),
                 'enable' => _scanwedgePlugin?.enableScanner(),
                 'disable' => _scanwedgePlugin?.disableScanner(),
-                'battery' => _scanwedgePlugin?.getBatteryStatus().then((status) => log('Battery status: $status')),
+                'battery' => _scanwedgePlugin
+                    ?.getBatteryStatus()
+                    .then((status) => log('Battery status: $status')),
                 'exit' => exit(0),
                 _ => null,
               },
@@ -107,7 +126,8 @@ class _MyAppState extends State<MyApp> {
           // mainAxisAlignment: MainAxisAlignment.spaceAround,
           children: [
             // ElevatedButton(onPressed: _scanwedgePlugin.test, child: const Text('Create profile')),
-            Text(_deviceInfo ?? 'No device info', style: Theme.of(context).textTheme.labelSmall),
+            Text(_deviceInfo ?? 'No device info',
+                style: Theme.of(context).textTheme.labelSmall),
             Card(
                 child: Padding(
               padding: const EdgeInsets.all(8.0),
@@ -127,7 +147,12 @@ class _MyAppState extends State<MyApp> {
                             const SizedBox(width: 5),
                             ValueListenableBuilder(
                                 valueListenable: notifierDisableKeystroke,
-                                builder: (context, disableKeyboard, _) => Switch(value: disableKeyboard, onChanged: (value) => notifierDisableKeystroke.value = value)),
+                                builder: (context, disableKeyboard, _) =>
+                                    Switch(
+                                        value: disableKeyboard,
+                                        onChanged: (value) =>
+                                            notifierDisableKeystroke.value =
+                                                value)),
                           ],
                         ),
                         ValueListenableBuilder(
@@ -138,36 +163,66 @@ class _MyAppState extends State<MyApp> {
                                   itemBuilder: ((context) => AimType.values
                                       .map((e) => PopupMenuItem(
                                             value: e,
-                                            child: Text(e.toString().split('.').last),
+                                            child: Text(
+                                                e.toString().split('.').last),
                                           ))
                                       .toList()),
                                   child: Container(
-                                    padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+                                    padding: const EdgeInsets.symmetric(
+                                        vertical: 4, horizontal: 8),
                                     decoration: BoxDecoration(
-                                        color: Colors.blue, borderRadius: BorderRadius.circular(5), boxShadow: const [BoxShadow(offset: Offset(2, 2), blurRadius: 1, color: Colors.black54)]),
+                                        color: Colors.blue,
+                                        borderRadius: BorderRadius.circular(5),
+                                        boxShadow: const [
+                                          BoxShadow(
+                                              offset: Offset(2, 2),
+                                              blurRadius: 1,
+                                              color: Colors.black54)
+                                        ]),
                                     child: Column(
                                       mainAxisSize: MainAxisSize.min,
-                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
                                       children: [
-                                        Text('AimType:', style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Colors.white)),
+                                        Text('AimType:',
+                                            style: Theme.of(context)
+                                                .textTheme
+                                                .bodyMedium
+                                                ?.copyWith(
+                                                    color: Colors.white)),
                                         Padding(
-                                          padding: const EdgeInsets.only(left: 6.0),
-                                          child: Text(aimType.toString().split('.').last, style: Theme.of(context).textTheme.titleLarge?.copyWith(color: Colors.white)),
+                                          padding:
+                                              const EdgeInsets.only(left: 6.0),
+                                          child: Text(
+                                              aimType
+                                                  .toString()
+                                                  .split('.')
+                                                  .last,
+                                              style: Theme.of(context)
+                                                  .textTheme
+                                                  .titleLarge
+                                                  ?.copyWith(
+                                                      color: Colors.white)),
                                         ),
                                       ],
                                     ),
                                   ),
-                                  onSelected: (newAimType) => notifierAimType.value = newAimType,
+                                  onSelected: (newAimType) =>
+                                      notifierAimType.value = newAimType,
                                 )),
                       ],
                     ),
                   ),
-                  ElevatedButton(onPressed: _createProfile, child: const Text('Create profile')),
+                  ElevatedButton(
+                      onPressed: _createProfile,
+                      child: const Text('Create profile')),
                 ],
               ),
             )),
             TextFormField(
-              decoration: const InputDecoration(hintText: 'auto inserted if keystroke and focused', contentPadding: EdgeInsets.symmetric(horizontal: 6)),
+              decoration: const InputDecoration(
+                  hintText: 'auto inserted if keystroke and focused',
+                  contentPadding: EdgeInsets.symmetric(horizontal: 6)),
             ),
             const Expanded(child: SizedBox()),
             Card(
@@ -187,7 +242,8 @@ class _MyAppState extends State<MyApp> {
                                         : snapshot.hasError
                                             ? snapshot.error.toString()
                                             : 'Scan something',
-                                    style: Theme.of(context).textTheme.titleMedium,
+                                    style:
+                                        Theme.of(context).textTheme.titleMedium,
                                   ))),
                         ],
                       )

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -13,6 +13,8 @@ class MyApp extends StatefulWidget {
 
   @override
   State<MyApp> createState() => _MyAppState();
+
+  final _demoProfileName = 'DemoProfile';
 }
 
 class _MyAppState extends State<MyApp> {
@@ -41,7 +43,7 @@ class _MyAppState extends State<MyApp> {
           await _scanwedgePlugin?.createScanProfile(
         switch (_scanwedgePlugin?.manufacturer) {
           'ZEBRA' => ZebraProfileModel(
-              profileName: 'DemoProfile',
+              profileName: widget._demoProfileName,
               enabledBarcodes: [
                 BarcodeConfig(barcodeType: BarcodeTypes.code39),
                 BarcodeConfig(barcodeType: BarcodeTypes.code128),
@@ -52,8 +54,17 @@ class _MyAppState extends State<MyApp> {
               enableKeyStroke: !notifierDisableKeystroke.value,
               aimType: notifierAimType.value,
             ),
+          'Honeywell' => HoneywellProfileModel(profileName: widget._demoProfileName,
+            enableEanCheckDigitTransmission: true,
+            enabledBarcodes: [
+              BarcodeConfig(barcodeType: BarcodeTypes.code39),
+              BarcodeConfig(barcodeType: BarcodeTypes.code128),
+              BarcodeConfig(barcodeType: BarcodeTypes.ean8),
+              BarcodeConfig(barcodeType: BarcodeTypes.ean13),
+            ],
+          ),
           _ => ProfileModel(
-              profileName: 'DemoProfile',
+              profileName: widget._demoProfileName,
               enabledBarcodes: [
                 BarcodeTypes.code39.create(),
                 BarcodeTypes.code128.create(minLength: 10, maxLength: 15),

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -18,8 +18,8 @@ void main() {
     // Verify that platform version is retrieved.
     expect(
       find.byWidgetPredicate(
-        (Widget widget) => widget is Text &&
-                           widget.data!.startsWith('Running on:'),
+        (Widget widget) =>
+            widget is Text && widget.data!.startsWith('Running on:'),
       ),
       findsOneWidget,
     );

--- a/lib/models/profile_model.dart
+++ b/lib/models/profile_model.dart
@@ -26,9 +26,17 @@ class ProfileModel {
 
 /// HoneywellProfileModel class
 /// This class extends the [ProfileModel] class
-/// This currently have no additional settings from the [ProfileModel] but it might have more options later
+/// [enableEanCheckDigitTransmission] allows the last (13th) digit of an EAN-13 to be sent to with the barcode data
 class HoneywellProfileModel extends ProfileModel {
-  HoneywellProfileModel({required super.profileName, super.enabledBarcodes, super.keepDefaults});
+  final bool enableEanCheckDigitTransmission;
+  HoneywellProfileModel({required super.profileName, this.enableEanCheckDigitTransmission = false, super.enabledBarcodes, super.keepDefaults});
+
+  @override
+  Map<String, dynamic> get customMap => {
+    'honeywell': {
+        'enableEanCheckDigitTransmission': enableEanCheckDigitTransmission,
+    },
+  };
 }
 
 /// ZebraProfileModel class

--- a/lib/models/profile_model.dart
+++ b/lib/models/profile_model.dart
@@ -29,7 +29,13 @@ class ProfileModel {
 /// [enableEanCheckDigitTransmission] allows the last (13th) digit of an EAN-13 to be sent to with the barcode data
 class HoneywellProfileModel extends ProfileModel {
   final bool enableEanCheckDigitTransmission;
-  HoneywellProfileModel({required super.profileName, this.enableEanCheckDigitTransmission = false, super.enabledBarcodes, super.keepDefaults});
+
+  HoneywellProfileModel({
+    required super.profileName,
+    this.enableEanCheckDigitTransmission = true,
+    super.enabledBarcodes,
+    super.keepDefaults,
+  });
 
   @override
   Map<String, dynamic> get customMap => {


### PR DESCRIPTION
For an EAN-13 barcode such the one in the attachment:
![image](https://github.com/user-attachments/assets/fd19cedf-7c00-49d2-8b8f-797cf0ddc306)

The HW side of the plugin was not sending in the the last digit. This resulted in reading off only '871180900325'. This PR enables a setting that does transmit the check digit, by default. Used the [docs](https://pub.dev/packages/honeywell_scanner#fifth) from the HoneywellScanner package

Adds a new entry in HoneywellProfileModel: `final bool enableEanCheckDigitTransmission`
- `false` by default to preserve backwards compatibility of the plugin
    - Not sure if this is a sound assumption because the check digit is always part of the actual barcode
- overrides the custom map, to be sent to the native side
- deserializes it on the native side to conditionally apply it, during the 'create profile' phase

The demo has a new HoneywellProfile, with the property enabled to showcase it