### PR TITLE
Honeywell and Datalogic Android 13+ support

### DIFF
--- a/android/src/main/kotlin/no/talgoe/scanwedge/scanwedge/DatalogicPlugin.kt
+++ b/android/src/main/kotlin/no/talgoe/scanwedge/scanwedge/DatalogicPlugin.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Build
 
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -57,7 +58,11 @@ class DatalogicPlugin(private val scanW: ScanwedgePlugin, private val log: Logge
             try{
                 val filter = IntentFilter(ScanwedgePlugin.SCANWEDGE_ACTION)
                 filter.addCategory("SCAN")
-                context.registerReceiver(barcodeDataReceiver, filter)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+                    context.registerReceiver(barcodeDataReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
+                else
+                    context.registerReceiver(barcodeDataReceiver, filter)
+
                 scanW.sendBroadcast(Intent(ACTION_CONFIGURATION_COMMIT).apply{
                     putExtra(EXTRA_CONFIGURATION_CHANGED_MAP, "WEDGE_KEYBOARD_ENABLE=false,WEDGE_INTENT_ACTION_NAME=${ScanwedgePlugin.SCANWEDGE_ACTION},WEDGE_INTENT_CATEGORY_NAME=SCAN,WEDGE_INTENT_EXTRA_BARCODE_STRING=$ACTION_BARCODE_STRING,WEDGE_INTENT_EXTRA_BARCODE_DATA=$ACTION_EXTRABARCODE_STRING,WEDGE_INTENT_EXTRA_BARCODE_TYPE=$ACTION_BARCODE_TYPE,WEDGE_INTENT_ENABLE=true")
                 })

--- a/android/src/main/kotlin/no/talgoe/scanwedge/scanwedge/HoneywellPlugin.kt
+++ b/android/src/main/kotlin/no/talgoe/scanwedge/scanwedge/HoneywellPlugin.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Bundle
+import android.os.Build
 
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -63,7 +64,11 @@ class HoneywellPlugin(private val scanW: ScanwedgePlugin, private val log: Logge
             try{
                 val filter = IntentFilter(ScanwedgePlugin.SCANWEDGE_ACTION)
                 filter.addCategory("SCAN")
-                context.registerReceiver(barcodeDataReceiver, filter)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+                    context.registerReceiver(barcodeDataReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
+                else
+                    context.registerReceiver(barcodeDataReceiver, filter)
+
                 scanW.sendBroadcast(Intent(ACTION_RELEASE_SCANNER).apply{ setPackage("com.intermec.datacollectionservice") })
                 return true
             } catch (e: Exception) {


### PR DESCRIPTION
Implemented Android 13+ support for Honeywell and Datalogic devices.

Noticed this was already added for the Newland/Urovo plugins, but was missing for the Honeywell and Datalogic plugins.

Tested on the following devices:

- [x] Datalogic Memor 17 with Android 15 
- [x] Honeywell EDA52 with Android 13
- [x] Honeywell CT32 with Android 14