### PR TITLE
Prevent multiplication return of the scan result on hot restart

### DIFF
--- a/android/src/main/kotlin/no/talgoe/scanwedge/scanwedge/ScanwedgePlugin.kt
+++ b/android/src/main/kotlin/no/talgoe/scanwedge/scanwedge/ScanwedgePlugin.kt
@@ -124,6 +124,8 @@ class ScanwedgePlugin(private var log: Logger?=null): FlutterPlugin, MethodCallH
         result.error("INVALID_INPUTPARAMETERS", "Must provide a config", "Invalid config")
       }
     }else if(call.method=="initializeDataWedge"){
+      hardwarePlugin?.dispose(context)
+      hardwarePlugin = null
       // Checking if the device is a Zebra device. Checking that Build.MANUFACTURER or Build.MODEL starts with 'ZEBRA' using uppercase letters.
       log?.i(TAG, "isSupported-manufacturer: ${android.os.Build.MANUFACTURER}, model: ${android.os.Build.MODEL}")
       val manufacturer = android.os.Build.MANUFACTURER?.uppercase()?.split(" ")?.get(0)


### PR DESCRIPTION
Implemented disposal of the hardwarePlugin on initialization to prevent the multiplication return of the scan result with doing hot restarts of the app.

Tested on the following devices:

- [x] Datalogic Memor 17 with Android 15
- [x] Honeywell EDA52 with Android 13
- [x] Honeywell CT32 with Android 14
- [x] Newland MT95 with Android 13